### PR TITLE
Specify components in CMake package configs

### DIFF
--- a/Schweizer-Messer/sm_boost/cmake/Config.cmake.in
+++ b/Schweizer-Messer/sm_boost/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS system serialization thread)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 

--- a/Schweizer-Messer/sm_common/cmake/Config.cmake.in
+++ b/Schweizer-Messer/sm_common/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS system)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 

--- a/Schweizer-Messer/sm_eigen/cmake/Config.cmake.in
+++ b/Schweizer-Messer/sm_eigen/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS system serialization)
 find_dependency(Eigen3)
 find_dependency(sm_common)
 find_dependency(sm_random)

--- a/Schweizer-Messer/sm_logging/cmake/Config.cmake.in
+++ b/Schweizer-Messer/sm_logging/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS regex system thread)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 

--- a/Schweizer-Messer/sm_opencv/cmake/Config.cmake.in
+++ b/Schweizer-Messer/sm_opencv/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS system)
 find_dependency(sm_common)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/Schweizer-Messer/sm_property_tree/cmake/Config.cmake.in
+++ b/Schweizer-Messer/sm_property_tree/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS system filesystem)
 find_dependency(sm_common)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/Schweizer-Messer/sm_random/cmake/Config.cmake.in
+++ b/Schweizer-Messer/sm_random/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS system)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 

--- a/Schweizer-Messer/sm_timing/cmake/Config.cmake.in
+++ b/Schweizer-Messer/sm_timing/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS system)
 find_dependency(sm_common)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/aslam_cv/aslam_time/cmake/Config.cmake.in
+++ b/aslam_cv/aslam_time/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Boost)
+find_dependency(Boost COMPONENTS system)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 


### PR DESCRIPTION
This is required for CMake to correctly build/import require packages from dependencies.