### PR TITLE
Fix model parameter serialization for non-pinhole models

### DIFF
--- a/aslam_offline_calibration/kalibr2/include/kalibr2/CameraCalibrator.hpp
+++ b/aslam_offline_calibration/kalibr2/include/kalibr2/CameraCalibrator.hpp
@@ -17,6 +17,9 @@
 
 namespace kalibr2 {
 
+template <typename T>
+inline constexpr bool dependent_false_v = false;
+
 /// @brief Model-agnostic camera intrinsics for export.
 ///
 /// Contains the linear intrinsics and all non-linear parameters (distortion coefficients
@@ -174,7 +177,7 @@ class CameraCalibrator : public CameraCalibratorBase {
                          !std::is_same_v<CameraT, models::EquidistantPinhole> &&
                          !std::is_same_v<CameraT, models::EquidistantPinholeRs> &&
                          !std::is_same_v<CameraT, models::FovPinhole>) {
-      static_assert(sizeof(CameraT) == 0, "GetCameraInfoParams() not implemented for this camera model");
+      static_assert(dependent_false_v<CameraT>, "GetCameraInfoParams() not implemented for this camera model");
     }
 
     // Models that push extra scalars into d[] above (xi, alpha, beta) always use NoDistortion,

--- a/aslam_offline_calibration/kalibr2/include/kalibr2/CameraCalibrator.hpp
+++ b/aslam_offline_calibration/kalibr2/include/kalibr2/CameraCalibrator.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <string>
+#include <type_traits>
+#include <vector>
+
 #include <aslam/backend/CameraDesignVariable.hpp>
 #include <aslam/backend/HomogeneousExpression.hpp>
 #include <aslam/backend/HomogeneousPoint.hpp>
@@ -12,6 +16,16 @@
 #include <kalibr2/CameraModels.hpp>
 
 namespace kalibr2 {
+
+/// @brief Model-agnostic camera intrinsics for export.
+///
+/// Contains the linear intrinsics and all non-linear parameters (distortion coefficients
+/// and model-specific scalars such as xi, alpha, beta) packed into d[]. The interpretation
+/// of d[] is format-specific and handled by the consuming layer (e.g. kalibr2_ros).
+struct CameraInfoParams {
+  double fx, fy, cx, cy;
+  std::vector<double> d;  // model-specific scalars (xi, alpha, beta) first, then distortion coefficients
+};
 
 /**
  * @brief Abstract base class for camera calibration.
@@ -79,6 +93,13 @@ class CameraCalibratorBase {
 
   virtual void PrintReprojectionErrorsMean() const = 0;
   virtual void PrintReprojectionErrorStatistics() const = 0;
+
+  /**
+   * @brief Extract calibrated intrinsics and non-linear parameters.
+   * @return CameraInfoParams with fx, fy, cx, cy and d[] containing model-specific
+   *         scalars (xi, alpha, beta) followed by distortion coefficients.
+   */
+  virtual CameraInfoParams GetCameraInfoParams() const = 0;
 };
 
 template <typename CameraT>
@@ -128,6 +149,43 @@ class CameraCalibrator : public CameraCalibratorBase {
   }
 
   boost::shared_ptr<aslam::cameras::CameraGeometryBase> camera_geometry() const { return camera_geometry_; }
+
+  CameraInfoParams GetCameraInfoParams() const override {
+    CameraInfoParams result;
+
+    const auto K = camera_geometry_->projection().getCameraMatrix();
+    result.fx = K(0, 0);
+    result.fy = K(1, 1);
+    result.cx = K(0, 2);
+    result.cy = K(1, 2);
+
+    // Non-pinhole models (Omni, DS, EUCM) pack model-specific scalars (xi, alpha, beta)
+    // into their projection vector with no uniform accessor to extract them separately.
+    // Named accessors (xi(), alpha(), beta()) are the only way to retrieve them.
+    if constexpr (std::is_same_v<CameraT, models::DoubleSphere>) {
+      result.d = {camera_geometry_->projection().xi(), camera_geometry_->projection().alpha()};
+    } else if constexpr (std::is_same_v<CameraT, models::ExtendedUnified>) {
+      result.d = {camera_geometry_->projection().alpha(), camera_geometry_->projection().beta()};
+    } else if constexpr (std::is_same_v<CameraT, models::Omni> || std::is_same_v<CameraT, models::DistortedOmni> ||
+                         std::is_same_v<CameraT, models::DistortedOmniRs>) {
+      result.d.push_back(camera_geometry_->projection().xi());
+    } else if constexpr (!std::is_same_v<CameraT, models::DistortedPinhole> &&
+                         !std::is_same_v<CameraT, models::DistortedPinholeRs> &&
+                         !std::is_same_v<CameraT, models::EquidistantPinhole> &&
+                         !std::is_same_v<CameraT, models::EquidistantPinholeRs> &&
+                         !std::is_same_v<CameraT, models::FovPinhole>) {
+      static_assert(sizeof(CameraT) == 0, "GetCameraInfoParams() not implemented for this camera model");
+    }
+
+    // Models that push extra scalars into d[] above (xi, alpha, beta) always use NoDistortion,
+    // so this appends nothing for them. For DistortedOmni it appends radtan coeffs after xi.
+    // If a custom distortion model is used, it should be handled here.
+    Eigen::MatrixXd dist;
+    camera_geometry_->projection().distortion().getParameters(dist);
+    for (int i = 0; i < dist.size(); ++i) result.d.push_back(dist(i));
+
+    return result;
+  }
 
  private:
   // Returning the designvariable and then passing it to another function makes the data types

--- a/aslam_offline_calibration/kalibr2_ros/include/kalibr2_ros/KalibrToROSConverter.hpp
+++ b/aslam_offline_calibration/kalibr2_ros/include/kalibr2_ros/KalibrToROSConverter.hpp
@@ -40,7 +40,7 @@ static const std::unordered_map<std::string, std::string> kKalibrToROSDistortion
     {"eucm-none", ""},
 
     // Double sphere model (not supported in standard ROS CameraInfo)
-    {"ds-none", ""},
+    {"ds-none", "double_sphere"},
 };
 
 /// @brief Convert a Kalibr2 camera model name to a ROS CameraInfo distortion model name

--- a/aslam_offline_calibration/kalibr2_ros/src/ROSToYAMLConverter.cpp
+++ b/aslam_offline_calibration/kalibr2_ros/src/ROSToYAMLConverter.cpp
@@ -30,70 +30,33 @@ void tfMessageToYAML(const tf2_msgs::msg::TFMessage& tf_message, const std::file
 void CalibratorToYAML(const boost::shared_ptr<CameraCalibratorBase>& calibrator, const std::string& model,
                       const std::string& frame_id, size_t width, size_t height,
                       const std::filesystem::path& yaml_file) {
-  // Get the camera geometry which stores the intrinsic parameters
-  auto camera_geometry = calibrator->camera_geometry();
+  const auto p = calibrator->GetCameraInfoParams();
 
-  // Get projection parameters (intrinsics)
-  Eigen::MatrixXd projection_params;
-  camera_geometry->getParameters(projection_params, true, false, false);
-
-  // Get distortion parameters
-  Eigen::MatrixXd distortion_params;
-  camera_geometry->getParameters(distortion_params, false, true, false);
-
-  // Create CameraInfo message
   sensor_msgs::msg::CameraInfo camera_info;
-
-  // Set frame ID
   camera_info.header.frame_id = frame_id;
-
-  // Set image dimensions
   camera_info.width = width;
   camera_info.height = height;
 
-  // Assuming pinhole model: projection_params contains [fx, fy, cx, cy]
   // K = [fx  0  cx]
   //     [ 0 fy  cy]
   //     [ 0  0   1]
-  if (projection_params.size() >= 4) {
-    camera_info.k[0] = projection_params(0);  // fx
-    camera_info.k[1] = 0.0;
-    camera_info.k[2] = projection_params(2);  // cx
-    camera_info.k[3] = 0.0;
-    camera_info.k[4] = projection_params(1);  // fy
-    camera_info.k[5] = projection_params(3);  // cy
-    camera_info.k[6] = 0.0;
-    camera_info.k[7] = 0.0;
-    camera_info.k[8] = 1.0;
+  camera_info.k[0] = p.fx;
+  camera_info.k[2] = p.cx;
+  camera_info.k[4] = p.fy;
+  camera_info.k[5] = p.cy;
+  camera_info.k[8] = 1.0;
 
-    // Also set P matrix (projection matrix) - for rectified images, typically P = K
-    camera_info.p[0] = projection_params(0);  // fx
-    camera_info.p[1] = 0.0;
-    camera_info.p[2] = projection_params(2);  // cx
-    camera_info.p[3] = 0.0;
-    camera_info.p[4] = 0.0;
-    camera_info.p[5] = projection_params(1);  // fy
-    camera_info.p[6] = projection_params(3);  // cy
-    camera_info.p[7] = 0.0;
-    camera_info.p[8] = 0.0;
-    camera_info.p[9] = 0.0;
-    camera_info.p[10] = 1.0;
-    camera_info.p[11] = 0.0;
-  }
+  // P = [fx  0  cx  0]
+  //     [ 0  fy cy  0]
+  //     [ 0  0   1  0]
+  camera_info.p[0] = p.fx;
+  camera_info.p[2] = p.cx;
+  camera_info.p[5] = p.fy;
+  camera_info.p[6] = p.cy;
+  camera_info.p[10] = 1.0;
 
-  // Map kalibr model to ROS distortion model
-  std::string ros_distortion_model = ToROSDistortionModel(model);
-
-  // Set distortion model and coefficients
-  camera_info.distortion_model = ros_distortion_model;
-  if (distortion_params.size() > 0) {
-    camera_info.d.resize(distortion_params.size());
-    for (int i = 0; i < distortion_params.size(); ++i) {
-      camera_info.d[i] = distortion_params(i);
-    }
-  } else {
-    camera_info.d.resize(0);
-  }
+  camera_info.distortion_model = ToROSDistortionModel(model);
+  camera_info.d = p.d;
 
   // Set rectification matrix to identity, no rectification by default.
   camera_info.r[0] = 1.0;


### PR DESCRIPTION
The `kalibr` backend stores non-pinhole model scalars (xi, alpha, beta) inside the `projection` parameter vector with no uniform layout, so index-based access via `getParameters()` was silently producing wrong intrinsics for non-pinhole models.

This patch introduces `CameraInfoParams` as a model-agnostic extraction layer: it pulls linear intrinsics via `getCameraMatrix()` and routes model-specific scalars through their named accessors, appending them to `d[]` before the distortion coefficients. 

  - Pinhole models are unaffected. 
  - Also fixes the DS distortion model string, which was mapped to `""` instead of `"double_sphere"`.

